### PR TITLE
Create Chrome usage monitoring dashboard with Chart.js

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import Head from "next/head";
-import Image from "next/image";
+import Script from "next/script";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Geist, Geist_Mono } from "next/font/google";
 import styles from "@/styles/Home.module.css";
 
@@ -13,104 +14,586 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+type ChartDataset = Record<string, unknown> & { data: number[] };
+
+type ChartConfig = {
+  type: string;
+  data: {
+    labels: string[];
+    datasets: ChartDataset[];
+  };
+  options: Record<string, unknown>;
+};
+
+type ChartInstance = {
+  destroy: () => void;
+};
+
+type ChartConstructor = new (ctx: HTMLCanvasElement, config: ChartConfig) => ChartInstance;
+
+declare global {
+  interface Window {
+    Chart?: ChartConstructor;
+  }
+}
+
+type Metric = {
+  label: string;
+  value: string;
+  change: string;
+};
+
+type DailyUsage = {
+  day: string;
+  date: string;
+  minutes: number;
+  tabs: number;
+  focus: number;
+};
+
+type UrlVisit = {
+  domain: string;
+  title: string;
+  visits: number;
+  minutes: number;
+  category: string;
+  lastOpened: string;
+};
+
+type Highlight = {
+  title: string;
+  detail: string;
+  status: "positive" | "neutral" | "warning";
+};
+
+type DoughnutTooltipContext = {
+  label?: string;
+  parsed: number;
+  dataset: {
+    data: number[];
+  };
+};
+
+interface ChartCardProps {
+  title: string;
+  subtitle: string;
+  config: ChartConfig;
+  ready: boolean;
+}
+
+const formatDuration = (minutes: number) => {
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+
+  if (!hours) {
+    return `${remaining} min`;
+  }
+
+  return `${hours}h ${remaining.toString().padStart(2, "0")}m`;
+};
+
+const MetricCard = ({ label, value, change }: Metric) => (
+  <div className={styles.metricCard}>
+    <p className={styles.metricLabel}>{label}</p>
+    <p className={styles.metricValue}>{value}</p>
+    <p className={styles.metricChange}>{change}</p>
+  </div>
+);
+
+const ChartCard = ({ title, subtitle, config, ready }: ChartCardProps) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    if (!ready || typeof window === "undefined" || !window.Chart) {
+      return;
+    }
+
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    const chartInstance = new window.Chart(canvas, config);
+
+    return () => {
+      chartInstance?.destroy();
+    };
+  }, [config, ready]);
+
+  return (
+    <div className={styles.chartCard}>
+      <div className={styles.chartHeader}>
+        <h3>{title}</h3>
+        <p>{subtitle}</p>
+      </div>
+      <div className={styles.chartCanvas}>
+        <canvas ref={canvasRef} aria-label={title} role="img" />
+        {!ready && <div className={styles.loading}>Loading Chart.js…</div>}
+      </div>
+    </div>
+  );
+};
+
+const Highlights = ({ items }: { items: Highlight[] }) => (
+  <div className={styles.highlights}>
+    <h3>Daily highlights</h3>
+    <ul>
+      {items.map((item) => (
+        <li key={item.title} data-status={item.status}>
+          <span className={styles.highlightTitle}>{item.title}</span>
+          <span className={styles.highlightDetail}>{item.detail}</span>
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
 export default function Home() {
+  const [isChartReady, setIsChartReady] = useState(false);
+
+  const dailyUsage = useMemo<DailyUsage[]>(
+    () => [
+      { day: "Mon", date: "Nov 18", minutes: 142, tabs: 34, focus: 76 },
+      { day: "Tue", date: "Nov 19", minutes: 168, tabs: 41, focus: 71 },
+      { day: "Wed", date: "Nov 20", minutes: 154, tabs: 38, focus: 74 },
+      { day: "Thu", date: "Nov 21", minutes: 179, tabs: 45, focus: 69 },
+      { day: "Fri", date: "Nov 22", minutes: 201, tabs: 52, focus: 64 },
+      { day: "Sat", date: "Nov 23", minutes: 128, tabs: 29, focus: 82 },
+      { day: "Sun", date: "Nov 24", minutes: 96, tabs: 22, focus: 88 },
+    ],
+    []
+  );
+
+  const urlVisits = useMemo<UrlVisit[]>(
+    () => [
+      {
+        domain: "mail.google.com",
+        title: "Gmail",
+        visits: 19,
+        minutes: 114,
+        category: "Communication",
+        lastOpened: "Today · 9:12 AM",
+      },
+      {
+        domain: "calendar.google.com",
+        title: "Google Calendar",
+        visits: 12,
+        minutes: 86,
+        category: "Productivity",
+        lastOpened: "Today · 8:45 AM",
+      },
+      {
+        domain: "github.com",
+        title: "GitHub",
+        visits: 17,
+        minutes: 142,
+        category: "Development",
+        lastOpened: "Yesterday · 6:32 PM",
+      },
+      {
+        domain: "news.ycombinator.com",
+        title: "Hacker News",
+        visits: 9,
+        minutes: 58,
+        category: "Research",
+        lastOpened: "Yesterday · 9:18 PM",
+      },
+      {
+        domain: "notion.so",
+        title: "Notion workspace",
+        visits: 14,
+        minutes: 121,
+        category: "Knowledge base",
+        lastOpened: "Thu · 3:04 PM",
+      },
+      {
+        domain: "figma.com",
+        title: "Figma",
+        visits: 7,
+        minutes: 64,
+        category: "Design",
+        lastOpened: "Wed · 4:27 PM",
+      },
+    ],
+    []
+  );
+
+  const categoryBreakdown = useMemo(
+    () => [
+      { label: "Productivity", minutes: 428, color: "#38bdf8" },
+      { label: "Development", minutes: 312, color: "#6366f1" },
+      { label: "Research", minutes: 204, color: "#f472b6" },
+      { label: "Entertainment", minutes: 126, color: "#facc15" },
+      { label: "Other", minutes: 92, color: "#94a3b8" },
+    ],
+    []
+  );
+
+  const totalMinutes = useMemo(
+    () => dailyUsage.reduce((sum, day) => sum + day.minutes, 0),
+    [dailyUsage]
+  );
+
+  const totalTabs = useMemo(
+    () => dailyUsage.reduce((sum, day) => sum + day.tabs, 0),
+    [dailyUsage]
+  );
+
+  const averageFocus = useMemo(
+    () =>
+      Math.round(
+        dailyUsage.reduce((sum, day) => sum + day.focus, 0) / dailyUsage.length
+      ),
+    [dailyUsage]
+  );
+
+  const busiestDay = useMemo(() => {
+    return dailyUsage.reduce((max, day) => (day.tabs > max.tabs ? day : max), dailyUsage[0]);
+  }, [dailyUsage]);
+
+  const summaryMetrics = useMemo<Metric[]>(
+    () => [
+      {
+        label: "Active browsing time",
+        value: formatDuration(totalMinutes),
+        change: "+12% vs last week",
+      },
+      {
+        label: "Tabs opened",
+        value: totalTabs.toString(),
+        change: `Peak ${busiestDay.tabs} tabs on ${busiestDay.day}`,
+      },
+      {
+        label: "Average focus score",
+        value: `${averageFocus}%`,
+        change: "Goal ≥ 75%",
+      },
+      {
+        label: "Most visited domain",
+        value: urlVisits[0].domain,
+        change: `${urlVisits[0].visits} visits this week`,
+      },
+    ],
+    [averageFocus, busiestDay, totalMinutes, totalTabs, urlVisits]
+  );
+
+  const usageTrendConfig = useMemo<ChartConfig>(
+    () => ({
+      type: "line",
+      data: {
+        labels: dailyUsage.map((day) => `${day.day} · ${day.date}`),
+        datasets: [
+          {
+            label: "Active minutes",
+            data: dailyUsage.map((day) => day.minutes),
+            borderColor: "#38bdf8",
+            backgroundColor: "rgba(56, 189, 248, 0.18)",
+            borderWidth: 3,
+            fill: true,
+            tension: 0.4,
+            pointRadius: 4,
+          },
+          {
+            label: "Focus score",
+            data: dailyUsage.map((day) => day.focus),
+            borderColor: "#f472b6",
+            backgroundColor: "rgba(244, 114, 182, 0.16)",
+            borderDash: [8, 6],
+            borderWidth: 2,
+            tension: 0.3,
+            yAxisID: "y1",
+            pointRadius: 0,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: {
+          mode: "index",
+          intersect: false,
+        },
+        plugins: {
+          legend: {
+            labels: {
+              color: "#cbd5f5",
+              font: {
+                family: "var(--font-geist-sans)",
+              },
+            },
+          },
+          tooltip: {
+            backgroundColor: "rgba(15, 23, 42, 0.92)",
+            titleColor: "#f8fafc",
+            bodyColor: "#e2e8f0",
+            borderColor: "rgba(148, 163, 184, 0.35)",
+            borderWidth: 1,
+            padding: 12,
+            displayColors: true,
+          },
+        },
+        scales: {
+          y: {
+            beginAtZero: true,
+            title: {
+              display: true,
+              text: "Minutes",
+              color: "#cbd5f5",
+            },
+            ticks: {
+              color: "#94a3b8",
+            },
+            grid: {
+              color: "rgba(148, 163, 184, 0.15)",
+            },
+          },
+          y1: {
+            beginAtZero: true,
+            max: 100,
+            position: "right",
+            title: {
+              display: true,
+              text: "Focus %",
+              color: "#cbd5f5",
+            },
+            ticks: {
+              color: "#94a3b8",
+              callback: (value: number) => `${value}%`,
+            },
+            grid: {
+              drawOnChartArea: false,
+            },
+          },
+          x: {
+            ticks: {
+              color: "#94a3b8",
+              maxRotation: 0,
+            },
+            grid: {
+              display: false,
+            },
+          },
+        },
+      },
+    }),
+    [dailyUsage]
+  );
+
+  const tabsConfig = useMemo<ChartConfig>(
+    () => ({
+      type: "bar",
+      data: {
+        labels: dailyUsage.map((day) => `${day.day} · ${day.date}`),
+        datasets: [
+          {
+            label: "Tabs opened",
+            data: dailyUsage.map((day) => day.tabs),
+            backgroundColor: "rgba(99, 102, 241, 0.75)",
+            borderRadius: 10,
+            hoverBackgroundColor: "rgba(99, 102, 241, 1)",
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            display: false,
+          },
+          tooltip: {
+            backgroundColor: "rgba(15, 23, 42, 0.92)",
+            titleColor: "#f8fafc",
+            bodyColor: "#e2e8f0",
+            borderColor: "rgba(99, 102, 241, 0.6)",
+            borderWidth: 1,
+          },
+        },
+        scales: {
+          y: {
+            beginAtZero: true,
+            ticks: {
+              color: "#94a3b8",
+            },
+            grid: {
+              color: "rgba(148, 163, 184, 0.15)",
+            },
+          },
+          x: {
+            ticks: {
+              color: "#94a3b8",
+              maxRotation: 0,
+            },
+            grid: {
+              display: false,
+            },
+          },
+        },
+      },
+    }),
+    [dailyUsage]
+  );
+
+  const categoryConfig = useMemo<ChartConfig>(
+    () => ({
+      type: "doughnut",
+      data: {
+        labels: categoryBreakdown.map((item) => item.label),
+        datasets: [
+          {
+            data: categoryBreakdown.map((item) => item.minutes),
+            backgroundColor: categoryBreakdown.map((item) => item.color),
+            borderColor: "rgba(15, 23, 42, 1)",
+            borderWidth: 2,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        cutout: "60%",
+        plugins: {
+          legend: {
+            position: "bottom",
+            labels: {
+              color: "#cbd5f5",
+              boxWidth: 12,
+            },
+          },
+          tooltip: {
+            backgroundColor: "rgba(15, 23, 42, 0.92)",
+            titleColor: "#f8fafc",
+            bodyColor: "#e2e8f0",
+            borderColor: "rgba(56, 189, 248, 0.35)",
+            borderWidth: 1,
+            callbacks: {
+              label: (context: DoughnutTooltipContext) => {
+                const label = context.label ?? "";
+                const value = context.parsed;
+                const total = context.dataset.data.reduce(
+                  (sum: number, current: number) => sum + current,
+                  0
+                );
+                const percent = Math.round((value / total) * 100);
+                return `${label}: ${formatDuration(value)} (${percent}%)`;
+              },
+            },
+          },
+        },
+      },
+    }),
+    [categoryBreakdown]
+  );
+
+  const highlights = useMemo<Highlight[]>(
+    () => [
+      {
+        title: "Deep work streak",
+        detail: "2h 55m focused session on Thu",
+        status: "positive",
+      },
+      {
+        title: "Tab discipline",
+        detail: "Average of 37 tabs per day",
+        status: "neutral",
+      },
+      {
+        title: "Weekend cooldown",
+        detail: "Usage down 52% on Sunday",
+        status: "warning",
+      },
+    ],
+    []
+  );
+
   return (
     <>
       <Head>
-        <title>Create Next App</title>
-        <meta name="description" content="Generated by create next app" />
+        <title>Chrome usage monitor</title>
+        <meta name="description" content="Track Chrome activity, tabs opened, and visited URLs." />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/favicon.ico" />
       </Head>
-      <div
-        className={`${styles.page} ${geistSans.variable} ${geistMono.variable}`}
-      >
+      <Script
+        src="https://cdn.jsdelivr.net/npm/chart.js"
+        strategy="afterInteractive"
+        onLoad={() => setIsChartReady(true)}
+      />
+      <div className={`${styles.page} ${geistSans.variable} ${geistMono.variable}`}>
         <main className={styles.main}>
-          <Image
-            className={styles.logo}
-            src="/next.svg"
-            alt="Next.js logo"
-            width={180}
-            height={38}
-            priority
-          />
-          <ol>
-            <li>
-              Get started by editing <code>pages/index.tsx</code>.
-            </li>
-            <li>Save and see your changes instantly.</li>
-          </ol>
+          <header className={styles.header}>
+            <div>
+              <span className={styles.tag}>Weekly Chrome insights</span>
+              <h1>Usage snapshot</h1>
+            </div>
+            <p>
+              Understand how Chrome is used across the week. Monitor active time, track how many
+              tabs were opened, and review the domains that claimed the most attention.
+            </p>
+            <div className={styles.timeframe}>Week of Nov 18 · Local timezone</div>
+          </header>
 
-          <div className={styles.ctas}>
-            <a
-              className={styles.primary}
-              href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Image
-                className={styles.logo}
-                src="/vercel.svg"
-                alt="Vercel logomark"
-                width={20}
-                height={20}
-              />
-              Deploy now
-            </a>
-            <a
-              href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-              target="_blank"
-              rel="noopener noreferrer"
-              className={styles.secondary}
-            >
-              Read our docs
-            </a>
-          </div>
+          <section className={styles.summaryGrid}>
+            {summaryMetrics.map((metric) => (
+              <MetricCard key={metric.label} {...metric} />
+            ))}
+          </section>
+
+          <section className={styles.visualGrid}>
+            <ChartCard
+              title="Active time vs. focus"
+              subtitle="Daily breakdown of minutes spent in Chrome"
+              config={usageTrendConfig}
+              ready={isChartReady}
+            />
+            <ChartCard
+              title="Tabs opened each day"
+              subtitle="Counts include new and restored tabs"
+              config={tabsConfig}
+              ready={isChartReady}
+            />
+            <ChartCard
+              title="Attention by category"
+              subtitle="Share of total active minutes"
+              config={categoryConfig}
+              ready={isChartReady}
+            />
+          </section>
+
+          <section className={styles.detailsGrid}>
+            <div className={styles.tableCard}>
+              <div className={styles.tableHeader}>
+                <h3>Most visited URLs</h3>
+                <p>Sorted by time on page</p>
+              </div>
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th scope="col">URL</th>
+                    <th scope="col">Category</th>
+                    <th scope="col">Visits</th>
+                    <th scope="col">Time spent</th>
+                    <th scope="col">Last opened</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {urlVisits.map((visit) => (
+                    <tr key={visit.domain}>
+                      <td>
+                        <span className={styles.urlTitle}>{visit.title}</span>
+                        <span className={styles.urlDomain}>{visit.domain}</span>
+                      </td>
+                      <td>{visit.category}</td>
+                      <td>{visit.visits}</td>
+                      <td>{formatDuration(visit.minutes)}</td>
+                      <td>{visit.lastOpened}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <Highlights items={highlights} />
+          </section>
         </main>
-        <footer className={styles.footer}>
-          <a
-            href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              aria-hidden
-              src="/file.svg"
-              alt="File icon"
-              width={16}
-              height={16}
-            />
-            Learn
-          </a>
-          <a
-            href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              aria-hidden
-              src="/window.svg"
-              alt="Window icon"
-              width={16}
-              height={16}
-            />
-            Examples
-          </a>
-          <a
-            href="https://nextjs.org?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              aria-hidden
-              src="/globe.svg"
-              alt="Globe icon"
-              width={16}
-              height={16}
-            />
-            Go to nextjs.org →
-          </a>
-        </footer>
       </div>
     </>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -66,6 +66,219 @@ type Highlight = {
   status: "positive" | "neutral" | "warning";
 };
 
+type CategorySlice = {
+  label: string;
+  minutes: number;
+  color: string;
+};
+
+type TimeframeKey = "week" | "month";
+
+type TimeframeData = {
+  label: string;
+  rangeLabel: string;
+  description: string;
+  dailyUsage: DailyUsage[];
+  urlVisits: UrlVisit[];
+  categoryBreakdown: CategorySlice[];
+  highlights: Highlight[];
+};
+
+const TIMEFRAME_DATA: Record<TimeframeKey, TimeframeData> = {
+  week: {
+    label: "This week",
+    rangeLabel: "Week of Nov 18",
+    description:
+      "Review how your focus and tab discipline evolved each day of the current week.",
+    dailyUsage: [
+      { day: "Mon", date: "Nov 18", minutes: 142, tabs: 34, focus: 76 },
+      { day: "Tue", date: "Nov 19", minutes: 168, tabs: 41, focus: 71 },
+      { day: "Wed", date: "Nov 20", minutes: 154, tabs: 38, focus: 74 },
+      { day: "Thu", date: "Nov 21", minutes: 179, tabs: 45, focus: 69 },
+      { day: "Fri", date: "Nov 22", minutes: 201, tabs: 52, focus: 64 },
+      { day: "Sat", date: "Nov 23", minutes: 128, tabs: 29, focus: 82 },
+      { day: "Sun", date: "Nov 24", minutes: 96, tabs: 22, focus: 88 },
+    ],
+    urlVisits: [
+      {
+        domain: "mail.google.com",
+        title: "Gmail",
+        visits: 19,
+        minutes: 114,
+        category: "Communication",
+        lastOpened: "Today · 9:12 AM",
+      },
+      {
+        domain: "calendar.google.com",
+        title: "Google Calendar",
+        visits: 12,
+        minutes: 86,
+        category: "Productivity",
+        lastOpened: "Today · 8:45 AM",
+      },
+      {
+        domain: "github.com",
+        title: "GitHub",
+        visits: 17,
+        minutes: 142,
+        category: "Development",
+        lastOpened: "Yesterday · 6:32 PM",
+      },
+      {
+        domain: "news.ycombinator.com",
+        title: "Hacker News",
+        visits: 9,
+        minutes: 58,
+        category: "Research",
+        lastOpened: "Yesterday · 9:18 PM",
+      },
+      {
+        domain: "notion.so",
+        title: "Notion workspace",
+        visits: 14,
+        minutes: 121,
+        category: "Knowledge base",
+        lastOpened: "Thu · 3:04 PM",
+      },
+      {
+        domain: "figma.com",
+        title: "Figma",
+        visits: 7,
+        minutes: 64,
+        category: "Design",
+        lastOpened: "Wed · 4:27 PM",
+      },
+    ],
+    categoryBreakdown: [
+      { label: "Productivity", minutes: 428, color: "#38bdf8" },
+      { label: "Development", minutes: 312, color: "#6366f1" },
+      { label: "Research", minutes: 204, color: "#f472b6" },
+      { label: "Entertainment", minutes: 126, color: "#facc15" },
+      { label: "Other", minutes: 92, color: "#94a3b8" },
+    ],
+    highlights: [
+      {
+        title: "Deep work streak",
+        detail: "2h 55m focused session on Thu",
+        status: "positive",
+      },
+      {
+        title: "Tab discipline",
+        detail: "Average of 37 tabs per day",
+        status: "neutral",
+      },
+      {
+        title: "Weekend cooldown",
+        detail: "Usage down 52% on Sunday",
+        status: "warning",
+      },
+    ],
+  },
+  month: {
+    label: "Last 4 weeks",
+    rangeLabel: "Nov 1 – Nov 28",
+    description:
+      "Zoom out to compare weekly totals and see how your focus trended across the month.",
+    dailyUsage: [
+      { day: "Week 1", date: "Nov 1 – 7", minutes: 986, tabs: 248, focus: 72 },
+      { day: "Week 2", date: "Nov 8 – 14", minutes: 1042, tabs: 265, focus: 70 },
+      { day: "Week 3", date: "Nov 15 – 21", minutes: 1116, tabs: 281, focus: 68 },
+      { day: "Week 4", date: "Nov 22 – 28", minutes: 994, tabs: 243, focus: 74 },
+    ],
+    urlVisits: [
+      {
+        domain: "mail.google.com",
+        title: "Gmail",
+        visits: 78,
+        minutes: 482,
+        category: "Communication",
+        lastOpened: "Today · 9:12 AM",
+      },
+      {
+        domain: "calendar.google.com",
+        title: "Google Calendar",
+        visits: 49,
+        minutes: 368,
+        category: "Productivity",
+        lastOpened: "Today · 8:45 AM",
+      },
+      {
+        domain: "github.com",
+        title: "GitHub",
+        visits: 66,
+        minutes: 587,
+        category: "Development",
+        lastOpened: "Yesterday · 6:32 PM",
+      },
+      {
+        domain: "docs.google.com",
+        title: "Project doc",
+        visits: 41,
+        minutes: 312,
+        category: "Documentation",
+        lastOpened: "Yesterday · 4:18 PM",
+      },
+      {
+        domain: "news.ycombinator.com",
+        title: "Hacker News",
+        visits: 34,
+        minutes: 236,
+        category: "Research",
+        lastOpened: "Tue · 9:58 PM",
+      },
+      {
+        domain: "linear.app",
+        title: "Linear tasks",
+        visits: 37,
+        minutes: 274,
+        category: "Productivity",
+        lastOpened: "Tue · 3:21 PM",
+      },
+      {
+        domain: "youtube.com",
+        title: "Design reviews",
+        visits: 22,
+        minutes: 198,
+        category: "Learning",
+        lastOpened: "Mon · 10:07 PM",
+      },
+      {
+        domain: "notion.so",
+        title: "Team wiki",
+        visits: 43,
+        minutes: 356,
+        category: "Knowledge base",
+        lastOpened: "Sun · 11:48 AM",
+      },
+    ],
+    categoryBreakdown: [
+      { label: "Productivity", minutes: 1812, color: "#38bdf8" },
+      { label: "Development", minutes: 1584, color: "#6366f1" },
+      { label: "Research", minutes: 944, color: "#f472b6" },
+      { label: "Learning", minutes: 668, color: "#facc15" },
+      { label: "Documentation", minutes: 312, color: "#34d399" },
+      { label: "Other", minutes: 286, color: "#94a3b8" },
+    ],
+    highlights: [
+      {
+        title: "Focus rebound",
+        detail: "Week 4 focus climbed back to 74%",
+        status: "positive",
+      },
+      {
+        title: "GitHub heavy",
+        detail: "Nearly 10 hours spent reviewing pull requests",
+        status: "neutral",
+      },
+      {
+        title: "Docs surge",
+        detail: "Documentation time up 26% versus last month",
+        status: "warning",
+      },
+    ],
+  },
+};
+
 type DoughnutTooltipContext = {
   label?: string;
   parsed: number;
@@ -151,83 +364,45 @@ const Highlights = ({ items }: { items: Highlight[] }) => (
 export default function Home() {
   const [isChartReady, setIsChartReady] = useState(false);
 
-  const dailyUsage = useMemo<DailyUsage[]>(
-    () => [
-      { day: "Mon", date: "Nov 18", minutes: 142, tabs: 34, focus: 76 },
-      { day: "Tue", date: "Nov 19", minutes: 168, tabs: 41, focus: 71 },
-      { day: "Wed", date: "Nov 20", minutes: 154, tabs: 38, focus: 74 },
-      { day: "Thu", date: "Nov 21", minutes: 179, tabs: 45, focus: 69 },
-      { day: "Fri", date: "Nov 22", minutes: 201, tabs: 52, focus: 64 },
-      { day: "Sat", date: "Nov 23", minutes: 128, tabs: 29, focus: 82 },
-      { day: "Sun", date: "Nov 24", minutes: 96, tabs: 22, focus: 88 },
-    ],
+  const [timeframe, setTimeframe] = useState<TimeframeKey>("week");
+  const [categoryFilter, setCategoryFilter] = useState<string>("all");
+  const [searchTerm, setSearchTerm] = useState<string>("");
+
+  const timeframeData = useMemo(() => TIMEFRAME_DATA[timeframe], [timeframe]);
+
+  const timeframeOptions = useMemo(
+    () => Object.entries(TIMEFRAME_DATA) as [TimeframeKey, TimeframeData][],
     []
   );
 
-  const urlVisits = useMemo<UrlVisit[]>(
-    () => [
-      {
-        domain: "mail.google.com",
-        title: "Gmail",
-        visits: 19,
-        minutes: 114,
-        category: "Communication",
-        lastOpened: "Today · 9:12 AM",
-      },
-      {
-        domain: "calendar.google.com",
-        title: "Google Calendar",
-        visits: 12,
-        minutes: 86,
-        category: "Productivity",
-        lastOpened: "Today · 8:45 AM",
-      },
-      {
-        domain: "github.com",
-        title: "GitHub",
-        visits: 17,
-        minutes: 142,
-        category: "Development",
-        lastOpened: "Yesterday · 6:32 PM",
-      },
-      {
-        domain: "news.ycombinator.com",
-        title: "Hacker News",
-        visits: 9,
-        minutes: 58,
-        category: "Research",
-        lastOpened: "Yesterday · 9:18 PM",
-      },
-      {
-        domain: "notion.so",
-        title: "Notion workspace",
-        visits: 14,
-        minutes: 121,
-        category: "Knowledge base",
-        lastOpened: "Thu · 3:04 PM",
-      },
-      {
-        domain: "figma.com",
-        title: "Figma",
-        visits: 7,
-        minutes: 64,
-        category: "Design",
-        lastOpened: "Wed · 4:27 PM",
-      },
-    ],
-    []
+  const dailyUsage = timeframeData.dailyUsage;
+  const urlVisits = timeframeData.urlVisits;
+  const categoryBreakdown = timeframeData.categoryBreakdown;
+  const highlights = timeframeData.highlights;
+  const timeframeRangeLabel = timeframeData.rangeLabel;
+  const timeframeDescription = timeframeData.description;
+
+  useEffect(() => {
+    setCategoryFilter("all");
+    setSearchTerm("");
+  }, [timeframe]);
+
+  const categories = useMemo(
+    () => ["all", ...new Set(urlVisits.map((visit) => visit.category))],
+    [urlVisits]
   );
 
-  const categoryBreakdown = useMemo(
-    () => [
-      { label: "Productivity", minutes: 428, color: "#38bdf8" },
-      { label: "Development", minutes: 312, color: "#6366f1" },
-      { label: "Research", minutes: 204, color: "#f472b6" },
-      { label: "Entertainment", minutes: 126, color: "#facc15" },
-      { label: "Other", minutes: 92, color: "#94a3b8" },
-    ],
-    []
-  );
+  const filteredVisits = useMemo(() => {
+    return urlVisits.filter((visit) => {
+      const matchesCategory =
+        categoryFilter === "all" || visit.category === categoryFilter;
+      const matchesQuery = searchTerm
+        ? `${visit.title} ${visit.domain}`.toLowerCase().includes(searchTerm.toLowerCase())
+        : true;
+
+      return matchesCategory && matchesQuery;
+    });
+  }, [categoryFilter, searchTerm, urlVisits]);
 
   const totalMinutes = useMemo(
     () => dailyUsage.reduce((sum, day) => sum + day.minutes, 0),
@@ -485,26 +660,18 @@ export default function Home() {
     [categoryBreakdown]
   );
 
-  const highlights = useMemo<Highlight[]>(
-    () => [
-      {
-        title: "Deep work streak",
-        detail: "2h 55m focused session on Thu",
-        status: "positive",
-      },
-      {
-        title: "Tab discipline",
-        detail: "Average of 37 tabs per day",
-        status: "neutral",
-      },
-      {
-        title: "Weekend cooldown",
-        detail: "Usage down 52% on Sunday",
-        status: "warning",
-      },
-    ],
-    []
-  );
+  const usageSubtitle =
+    timeframe === "week"
+      ? "Daily breakdown of minutes spent in Chrome"
+      : "Weekly totals across the last four weeks";
+
+  const tabsSubtitle =
+    timeframe === "week"
+      ? "Counts include new and restored tabs"
+      : "Total tabs opened for each recorded week";
+
+  const timeframeTag =
+    timeframe === "week" ? "Weekly Chrome insights" : "Monthly Chrome insights";
 
   return (
     <>
@@ -521,15 +688,32 @@ export default function Home() {
       <div className={`${styles.page} ${geistSans.variable} ${geistMono.variable}`}>
         <main className={styles.main}>
           <header className={styles.header}>
-            <div>
-              <span className={styles.tag}>Weekly Chrome insights</span>
-              <h1>Usage snapshot</h1>
+            <div className={styles.headerTop}>
+              <div>
+                <span className={styles.tag}>{timeframeTag}</span>
+                <h1>Usage control center</h1>
+              </div>
+              <div className={styles.timeframeToggle} role="group" aria-label="Select time range">
+                {timeframeOptions.map(([key, option]) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setTimeframe(key)}
+                    data-active={timeframe === key}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
             </div>
             <p>
-              Understand how Chrome is used across the week. Monitor active time, track how many
-              tabs were opened, and review the domains that claimed the most attention.
+              Explore the interactive charts, filters, and highlights to understand how browsing
+              habits shift over time and which sites drive your focus.
             </p>
-            <div className={styles.timeframe}>Week of Nov 18 · Local timezone</div>
+            <div className={styles.metaRow}>
+              <div className={styles.timeframe}>{timeframeRangeLabel} · Local timezone</div>
+              <div className={styles.timeframeDescription}>{timeframeDescription}</div>
+            </div>
           </header>
 
           <section className={styles.summaryGrid}>
@@ -541,13 +725,13 @@ export default function Home() {
           <section className={styles.visualGrid}>
             <ChartCard
               title="Active time vs. focus"
-              subtitle="Daily breakdown of minutes spent in Chrome"
+              subtitle={usageSubtitle}
               config={usageTrendConfig}
               ready={isChartReady}
             />
             <ChartCard
-              title="Tabs opened each day"
-              subtitle="Counts include new and restored tabs"
+              title={timeframe === "week" ? "Tabs opened each day" : "Tabs opened each week"}
+              subtitle={tabsSubtitle}
               config={tabsConfig}
               ready={isChartReady}
             />
@@ -562,8 +746,34 @@ export default function Home() {
           <section className={styles.detailsGrid}>
             <div className={styles.tableCard}>
               <div className={styles.tableHeader}>
-                <h3>Most visited URLs</h3>
-                <p>Sorted by time on page</p>
+                <div>
+                  <h3>Most visited URLs</h3>
+                  <p>Sorted by time on page</p>
+                </div>
+                <div className={styles.tableControls}>
+                  <label className={styles.field}>
+                    <span>Search</span>
+                    <input
+                      type="search"
+                      placeholder="Filter titles or domains"
+                      value={searchTerm}
+                      onChange={(event) => setSearchTerm(event.target.value)}
+                    />
+                  </label>
+                  <label className={styles.field}>
+                    <span>Category</span>
+                    <select
+                      value={categoryFilter}
+                      onChange={(event) => setCategoryFilter(event.target.value)}
+                    >
+                      {categories.map((category) => (
+                        <option value={category} key={category}>
+                          {category === "all" ? "All" : category}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
               </div>
               <table className={styles.table}>
                 <thead>
@@ -576,18 +786,26 @@ export default function Home() {
                   </tr>
                 </thead>
                 <tbody>
-                  {urlVisits.map((visit) => (
-                    <tr key={visit.domain}>
-                      <td>
-                        <span className={styles.urlTitle}>{visit.title}</span>
-                        <span className={styles.urlDomain}>{visit.domain}</span>
+                  {filteredVisits.length > 0 ? (
+                    filteredVisits.map((visit) => (
+                      <tr key={`${visit.domain}-${visit.title}`}>
+                        <td>
+                          <span className={styles.urlTitle}>{visit.title}</span>
+                          <span className={styles.urlDomain}>{visit.domain}</span>
+                        </td>
+                        <td>{visit.category}</td>
+                        <td>{visit.visits}</td>
+                        <td>{formatDuration(visit.minutes)}</td>
+                        <td>{visit.lastOpened}</td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td className={styles.emptyRow} colSpan={5}>
+                        No URLs match your filters yet.
                       </td>
-                      <td>{visit.category}</td>
-                      <td>{visit.visits}</td>
-                      <td>{formatDuration(visit.minutes)}</td>
-                      <td>{visit.lastOpened}</td>
                     </tr>
-                  ))}
+                  )}
                 </tbody>
               </table>
             </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -367,6 +367,7 @@ export default function Home() {
   const [timeframe, setTimeframe] = useState<TimeframeKey>("week");
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
   const [searchTerm, setSearchTerm] = useState<string>("");
+  const [selectedDayIndex, setSelectedDayIndex] = useState(0);
 
   const timeframeData = useMemo(() => TIMEFRAME_DATA[timeframe], [timeframe]);
 
@@ -385,6 +386,7 @@ export default function Home() {
   useEffect(() => {
     setCategoryFilter("all");
     setSearchTerm("");
+    setSelectedDayIndex(0);
   }, [timeframe]);
 
   const categories = useMemo(
@@ -414,6 +416,8 @@ export default function Home() {
     [dailyUsage]
   );
 
+  const totalPeriods = dailyUsage.length;
+
   const averageFocus = useMemo(
     () =>
       Math.round(
@@ -422,9 +426,55 @@ export default function Home() {
     [dailyUsage]
   );
 
+  const averageTabsPerPeriod = useMemo(
+    () => (totalPeriods ? Math.round(totalTabs / totalPeriods) : 0),
+    [totalTabs, totalPeriods]
+  );
+
+  const averageMinutesPerPeriod = useMemo(
+    () => (totalPeriods ? Math.round(totalMinutes / totalPeriods) : 0),
+    [totalMinutes, totalPeriods]
+  );
+
   const busiestDay = useMemo(() => {
     return dailyUsage.reduce((max, day) => (day.tabs > max.tabs ? day : max), dailyUsage[0]);
   }, [dailyUsage]);
+
+  const selectedDay = dailyUsage[selectedDayIndex];
+
+  const selectedDayShare = useMemo(() => {
+    if (!selectedDay || totalMinutes === 0) {
+      return 0;
+    }
+
+    return Math.round((selectedDay.minutes / totalMinutes) * 100);
+  }, [selectedDay, totalMinutes]);
+
+  const focusDelta = useMemo(() => {
+    if (!selectedDay) {
+      return 0;
+    }
+
+    return selectedDay.focus - averageFocus;
+  }, [averageFocus, selectedDay]);
+
+  const tabDelta = useMemo(() => {
+    if (!selectedDay) {
+      return 0;
+    }
+
+    return selectedDay.tabs - averageTabsPerPeriod;
+  }, [averageTabsPerPeriod, selectedDay]);
+
+  const dayRank = useMemo(() => {
+    const ranking = dailyUsage
+      .map((day, index) => ({ index, minutes: day.minutes }))
+      .sort((a, b) => b.minutes - a.minutes);
+
+    const foundIndex = ranking.findIndex((item) => item.index === selectedDayIndex);
+
+    return foundIndex === -1 ? 0 : foundIndex + 1;
+  }, [dailyUsage, selectedDayIndex]);
 
   const summaryMetrics = useMemo<Metric[]>(
     () => [
@@ -451,6 +501,106 @@ export default function Home() {
     ],
     [averageFocus, busiestDay, totalMinutes, totalTabs, urlVisits]
   );
+
+  const selectedDayMetrics = useMemo(() => {
+    if (!selectedDay) {
+      return [] as Metric[];
+    }
+
+    const timeframeLabel = timeframe === "week" ? "week" : "period";
+    const focusDeltaLabel =
+      focusDelta === 0
+        ? "Matched your average focus"
+        : `${focusDelta > 0 ? "+" : ""}${focusDelta}% vs range avg`;
+
+    const tabDeltaLabel =
+      tabDelta === 0
+        ? "Tabs aligned with your average"
+        : `${tabDelta > 0 ? "+" : ""}${tabDelta} vs avg ${averageTabsPerPeriod}`;
+
+    const busierThanMost = dayRank !== 0 && dayRank <= Math.ceil(totalPeriods / 2);
+
+    const intensityDetail =
+      dayRank === 0
+        ? ""
+        : busierThanMost
+        ? "Busier than most days in this range"
+        : "Calmer than the majority of days";
+
+    return [
+      {
+        label: "Active minutes",
+        value: formatDuration(selectedDay.minutes),
+        change: `${selectedDayShare}% of this ${timeframeLabel}`,
+      },
+      {
+        label: "Tabs opened",
+        value: selectedDay.tabs.toString(),
+        change: tabDeltaLabel,
+      },
+      {
+        label: "Focus score",
+        value: `${selectedDay.focus}%`,
+        change: focusDeltaLabel,
+      },
+      {
+        label: "Intensity rank",
+        value: `#${dayRank || "-"} of ${totalPeriods}`,
+        change: intensityDetail,
+      },
+    ];
+  }, [
+    averageTabsPerPeriod,
+    dayRank,
+    focusDelta,
+    selectedDay,
+    selectedDayShare,
+    tabDelta,
+    timeframe,
+    totalPeriods,
+  ]);
+
+  const selectedDayInsights = useMemo(() => {
+    if (!selectedDay) {
+      return [] as string[];
+    }
+
+    const insights: string[] = [];
+
+    if (focusDelta >= 5) {
+      insights.push("Focus surged above baseline—double down on what worked here.");
+    } else if (focusDelta <= -5) {
+      insights.push("Focus dipped below your usual level—consider a shorter session next time.");
+    } else {
+      insights.push("Focus held steady with your range average—consistency unlocked.");
+    }
+
+    if (selectedDay.tabs === busiestDay.tabs) {
+      insights.push("Highest tab load of the range—perfect moment for tab groups or bookmarks.");
+    } else if (tabDelta > 0) {
+      insights.push("Tabs crept above average—batch similar work to stay organized.");
+    } else {
+      insights.push("Lean tab load kept context switching low—nice discipline.");
+    }
+
+    if (selectedDayShare >= 25) {
+      insights.push(`A quarter of total active time happened this ${timeframe === "week" ? "day" : "week"}.`);
+    } else if (selectedDay.minutes < averageMinutesPerPeriod) {
+      insights.push("Time on browser stayed below your typical cadence.");
+    } else {
+      insights.push("Time commitment matched your normal rhythm for this range.");
+    }
+
+    return insights;
+  }, [
+    averageMinutesPerPeriod,
+    busiestDay.tabs,
+    focusDelta,
+    selectedDay,
+    selectedDayShare,
+    tabDelta,
+    timeframe,
+  ]);
 
   const usageTrendConfig = useMemo<ChartConfig>(
     () => ({
@@ -673,6 +823,21 @@ export default function Home() {
   const timeframeTag =
     timeframe === "week" ? "Weekly Chrome insights" : "Monthly Chrome insights";
 
+  const timeframeUnitLabel = timeframe === "week" ? "day" : "week";
+
+  const hasPreviousDay = selectedDayIndex > 0;
+  const hasNextDay = selectedDayIndex < dailyUsage.length - 1;
+
+  const goToPreviousDay = () => {
+    setSelectedDayIndex((current) => Math.max(0, current - 1));
+  };
+
+  const goToNextDay = () => {
+    setSelectedDayIndex((current) =>
+      Math.min(dailyUsage.length ? dailyUsage.length - 1 : 0, current + 1)
+    );
+  };
+
   return (
     <>
       <Head>
@@ -720,6 +885,95 @@ export default function Home() {
             {summaryMetrics.map((metric) => (
               <MetricCard key={metric.label} {...metric} />
             ))}
+          </section>
+
+          <section className={styles.drilldownSection} aria-label="Interactive daily drilldown">
+            <div className={styles.drilldownHeader}>
+              <div>
+                <h3>Daily drilldown</h3>
+                <p>
+                  Tap through each {timeframeUnitLabel} to compare focus, time, and tab load for the
+                  current view.
+                </p>
+              </div>
+              <div
+                className={styles.drilldownNav}
+                role="group"
+                aria-label={`Browse ${timeframeUnitLabel} summaries`}
+              >
+                <button
+                  type="button"
+                  onClick={goToPreviousDay}
+                  disabled={!hasPreviousDay}
+                  aria-label={`View previous ${timeframeUnitLabel}`}
+                >
+                  <span aria-hidden>←</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={goToNextDay}
+                  disabled={!hasNextDay}
+                  aria-label={`View next ${timeframeUnitLabel}`}
+                >
+                  <span aria-hidden>→</span>
+                </button>
+              </div>
+            </div>
+            <div className={styles.drilldownBody}>
+              <ul className={styles.drilldownList}>
+                {dailyUsage.map((day, index) => {
+                  const isActive = index === selectedDayIndex;
+
+                  return (
+                    <li key={`${day.day}-${day.date}`}>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedDayIndex(index)}
+                        data-active={isActive}
+                        aria-pressed={isActive}
+                      >
+                        <span className={styles.drilldownDay}>{day.day}</span>
+                        <span className={styles.drilldownDate}>{day.date}</span>
+                        <span className={styles.drilldownMinutes}>{formatDuration(day.minutes)}</span>
+                        <span className={styles.drilldownFocus}>Focus {day.focus}%</span>
+                        <span className={styles.drilldownTabs}>{day.tabs} tabs</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+              {selectedDay && (
+                <div className={styles.drilldownDetails}>
+                  <header className={styles.drilldownDetailsHeader}>
+                    <div>
+                      <span className={styles.drilldownDetailsLabel}>Selected {timeframeUnitLabel}</span>
+                      <h4>
+                        {selectedDay.day}
+                        <span> · {selectedDay.date}</span>
+                      </h4>
+                    </div>
+                    <span className={styles.drilldownBadge}>{formatDuration(selectedDay.minutes)}</span>
+                  </header>
+                  <div className={styles.drilldownMetrics}>
+                    {selectedDayMetrics.map((metric) => (
+                      <div key={metric.label} className={styles.drilldownMetric}>
+                        <p className={styles.drilldownMetricLabel}>{metric.label}</p>
+                        <p className={styles.drilldownMetricValue}>{metric.value}</p>
+                        <p className={styles.drilldownMetricDetail}>{metric.change}</p>
+                      </div>
+                    ))}
+                  </div>
+                  <div className={styles.drilldownInsights}>
+                    <h5>Insights</h5>
+                    <ul>
+                      {selectedDayInsights.map((insight) => (
+                        <li key={insight}>{insight}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              )}
+            </div>
           </section>
 
           <section className={styles.visualGrid}>

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -1,168 +1,322 @@
 .page {
-  --gray-rgb: 0, 0, 0;
-  --gray-alpha-200: rgba(var(--gray-rgb), 0.08);
-  --gray-alpha-100: rgba(var(--gray-rgb), 0.05);
-
-  --button-primary-hover: #383838;
-  --button-secondary-hover: #f2f2f2;
-
-  display: grid;
-  grid-template-rows: 20px 1fr 20px;
-  align-items: center;
-  justify-items: center;
-  min-height: 100svh;
-  padding: 80px;
-  gap: 64px;
-  font-family: var(--font-geist-sans);
-}
-
-@media (prefers-color-scheme: dark) {
-  .page {
-    --gray-rgb: 255, 255, 255;
-    --gray-alpha-200: rgba(var(--gray-rgb), 0.145);
-    --gray-alpha-100: rgba(var(--gray-rgb), 0.06);
-
-    --button-primary-hover: #ccc;
-    --button-secondary-hover: #1a1a1a;
-  }
+  min-height: 100vh;
+  padding: 72px 32px 96px;
+  background: radial-gradient(circle at top left, rgba(99, 102, 241, 0.18), transparent 55%),
+    radial-gradient(circle at top right, rgba(56, 189, 248, 0.22), transparent 45%),
+    #020617;
+  color: #e2e8f0;
 }
 
 .main {
+  margin: 0 auto;
+  width: min(1160px, 100%);
   display: flex;
   flex-direction: column;
   gap: 32px;
-  grid-row-start: 2;
 }
 
-.main ol {
-  font-family: var(--font-geist-mono);
-  padding-left: 0;
-  margin: 0;
-  font-size: 14px;
-  line-height: 24px;
-  letter-spacing: -0.01em;
-  list-style-position: inside;
-}
-
-.main li:not(:last-of-type) {
-  margin-bottom: 8px;
-}
-
-.main code {
-  font-family: inherit;
-  background: var(--gray-alpha-100);
-  padding: 2px 4px;
-  border-radius: 4px;
-  font-weight: 600;
-}
-
-.ctas {
+.header {
   display: flex;
+  flex-direction: column;
   gap: 16px;
 }
 
-.ctas a {
-  appearance: none;
-  border-radius: 128px;
-  height: 48px;
-  padding: 0 20px;
-  border: none;
-  border: 1px solid transparent;
-  transition:
-    background 0.2s,
-    color 0.2s,
-    border-color 0.2s;
-  cursor: pointer;
-  display: flex;
+.header h1 {
+  font-size: clamp(2rem, 3vw + 0.5rem, 3rem);
+  font-weight: 600;
+  line-height: 1.1;
+}
+
+.header p {
+  max-width: 620px;
+  font-size: 1.05rem;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.tag {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  font-size: 16px;
-  line-height: 20px;
-  font-weight: 500;
-}
-
-a.primary {
-  background: var(--foreground);
-  color: var(--background);
   gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #a5b4fc;
 }
 
-a.secondary {
-  border-color: var(--gray-alpha-200);
-  min-width: 158px;
+.timeframe {
+  font-family: var(--font-geist-mono);
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.9);
 }
 
-.footer {
-  grid-row-start: 3;
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.metricCard {
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 20px;
+  padding: 20px 24px;
   display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.4);
+}
+
+.metricLabel {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.95);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.metricValue {
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.metricChange {
+  font-size: 0.95rem;
+  color: rgba(129, 140, 248, 0.9);
+}
+
+.visualGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 24px;
 }
 
-.footer a {
+.chartCard {
+  position: relative;
+  background: rgba(15, 23, 42, 0.72);
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  padding: 24px 28px;
   display: flex;
-  align-items: center;
-  gap: 8px;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.45);
 }
 
-.footer img {
-  flex-shrink: 0;
+.chartHeader h3 {
+  font-size: 1.35rem;
+  font-weight: 600;
+  margin-bottom: 4px;
 }
 
-/* Enable hover only on non-touch devices */
-@media (hover: hover) and (pointer: fine) {
-  a.primary:hover {
-    background: var(--button-primary-hover);
-    border-color: transparent;
-  }
-
-  a.secondary:hover {
-    background: var(--button-secondary-hover);
-    border-color: transparent;
-  }
-
-  .footer a:hover {
-    text-decoration: underline;
-    text-underline-offset: 4px;
-  }
+.chartHeader p {
+  font-size: 0.95rem;
+  color: rgba(148, 163, 184, 0.85);
 }
 
-@media (max-width: 600px) {
+.chartCanvas {
+  position: relative;
+  width: 100%;
+  height: 280px;
+}
+
+.chartCanvas canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.loading {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.95rem;
+  color: rgba(148, 163, 184, 0.8);
+  background: linear-gradient(
+    135deg,
+    rgba(30, 41, 59, 0.4),
+    rgba(30, 41, 59, 0.2)
+  );
+  border-radius: 16px;
+}
+
+.detailsGrid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
+}
+
+.tableCard {
+  background: rgba(15, 23, 42, 0.76);
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  padding: 28px;
+  box-shadow: 0 24px 52px rgba(15, 23, 42, 0.45);
+  overflow: hidden;
+}
+
+.tableHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 18px;
+}
+
+.tableHeader h3 {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.tableHeader p {
+  font-size: 0.95rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table thead th {
+  text-align: left;
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.75);
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.table tbody tr {
+  transition: background 0.2s ease;
+}
+
+.table tbody tr:hover {
+  background: rgba(30, 41, 59, 0.55);
+}
+
+.table tbody td {
+  padding: 14px 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.table tbody td:nth-child(3),
+.table tbody td:nth-child(4) {
+  font-family: var(--font-geist-mono);
+  font-size: 0.9rem;
+}
+
+.table tbody td:last-child {
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.urlTitle {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.urlDomain {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.8);
+  font-family: var(--font-geist-mono);
+}
+
+.highlights {
+  background: rgba(15, 23, 42, 0.76);
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  padding: 28px;
+  box-shadow: 0 24px 52px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.highlights h3 {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.highlights ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.highlights li {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(30, 41, 59, 0.55);
+}
+
+.highlights li[data-status="positive"] {
+  border-color: rgba(74, 222, 128, 0.35);
+}
+
+.highlights li[data-status="warning"] {
+  border-color: rgba(248, 113, 113, 0.38);
+}
+
+.highlightTitle {
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.highlightDetail {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.88);
+}
+
+@media (max-width: 1200px) {
   .page {
-    padding: 32px;
-    padding-bottom: 80px;
+    padding: 64px 24px 88px;
   }
 
-  .main {
-    align-items: center;
-  }
-
-  .main ol {
-    text-align: center;
-  }
-
-  .ctas {
-    flex-direction: column;
-  }
-
-  .ctas a {
-    font-size: 14px;
-    height: 40px;
-    padding: 0 16px;
-  }
-
-  a.secondary {
-    min-width: auto;
-  }
-
-  .footer {
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
+  .visualGrid {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .logo {
-    filter: invert();
+@media (max-width: 900px) {
+  .detailsGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .chartCanvas {
+    height: 240px;
+  }
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 48px 18px 72px;
+  }
+
+  .header p {
+    font-size: 0.95rem;
+  }
+
+  .metricValue {
+    font-size: 1.5rem;
+  }
+
+  .chartCard {
+    padding: 20px;
+  }
+
+  .table tbody td {
+    font-size: 0.9rem;
   }
 }

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -21,6 +21,14 @@
   gap: 16px;
 }
 
+.headerTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
 .header h1 {
   font-size: clamp(2rem, 3vw + 0.5rem, 3rem);
   font-weight: 600;
@@ -47,10 +55,57 @@
   color: #a5b4fc;
 }
 
+.timeframeToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.timeframeToggle button {
+  border: none;
+  background: transparent;
+  color: rgba(203, 213, 225, 0.85);
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.timeframeToggle button[data-active="true"] {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.9), rgba(56, 189, 248, 0.85));
+  color: #0f172a;
+  box-shadow: 0 12px 24px rgba(56, 189, 248, 0.25);
+}
+
+.timeframeToggle button:not([data-active="true"]):hover {
+  background: rgba(30, 41, 59, 0.8);
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px 24px;
+}
+
 .timeframe {
   font-family: var(--font-geist-mono);
   font-size: 0.85rem;
   color: rgba(148, 163, 184, 0.9);
+}
+
+.timeframeDescription {
+  flex: 1;
+  min-width: 240px;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.9rem;
 }
 
 .summaryGrid {
@@ -160,8 +215,10 @@
 
 .tableHeader {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
   margin-bottom: 18px;
 }
 
@@ -173,6 +230,39 @@
 .tableHeader p {
   font-size: 0.95rem;
   color: rgba(148, 163, 184, 0.85);
+}
+
+.tableControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.field input,
+.field select {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 12px;
+  padding: 10px 12px;
+  color: #e2e8f0;
+  font-size: 0.9rem;
+  font-family: inherit;
+  min-width: 200px;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.6);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
 }
 
 .table {
@@ -214,6 +304,12 @@
 
 .table tbody td:last-child {
   color: rgba(148, 163, 184, 0.85);
+}
+
+.emptyRow {
+  text-align: center;
+  padding: 32px 0;
+  color: rgba(148, 163, 184, 0.7);
 }
 
 .urlTitle {
@@ -294,6 +390,11 @@
     grid-template-columns: 1fr;
   }
 
+  .headerTop {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
   .chartCanvas {
     height: 240px;
   }
@@ -314,6 +415,16 @@
 
   .chartCard {
     padding: 20px;
+  }
+
+  .tableControls {
+    width: 100%;
+  }
+
+  .field input,
+  .field select {
+    width: 100%;
+    min-width: unset;
   }
 
   .table tbody td {

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -114,6 +114,245 @@
   gap: 16px;
 }
 
+.drilldownSection {
+  background: rgba(15, 23, 42, 0.78);
+  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  padding: 28px;
+  box-shadow: 0 28px 56px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.drilldownHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 16px 24px;
+}
+
+.drilldownHeader h3 {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.drilldownHeader p {
+  margin-top: 6px;
+  color: rgba(148, 163, 184, 0.85);
+  max-width: 520px;
+}
+
+.drilldownNav {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 999px;
+  padding: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.drilldownNav button {
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(30, 41, 59, 0.8);
+  color: #cbd5f5;
+  font-size: 1.1rem;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.drilldownNav button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.drilldownNav button:not(:disabled):hover {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.9), rgba(56, 189, 248, 0.85));
+  color: #0f172a;
+  transform: translateY(-1px);
+}
+
+.drilldownBody {
+  display: grid;
+  gap: 28px;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  align-items: start;
+}
+
+.drilldownList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+}
+
+.drilldownList li button {
+  width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.7);
+  color: #e2e8f0;
+  padding: 16px;
+  display: grid;
+  gap: 6px;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.drilldownList li button:hover {
+  transform: translateY(-2px);
+}
+
+.drilldownList li button[data-active="true"] {
+  border-color: rgba(56, 189, 248, 0.55);
+  background: linear-gradient(150deg, rgba(56, 189, 248, 0.2), rgba(99, 102, 241, 0.16));
+  box-shadow: 0 20px 36px rgba(15, 23, 42, 0.4);
+}
+
+.drilldownDay {
+  font-weight: 600;
+}
+
+.drilldownDate {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.drilldownMinutes {
+  font-family: var(--font-geist-mono);
+  font-size: 0.9rem;
+  color: #a5b4fc;
+}
+
+.drilldownFocus,
+.drilldownTabs {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.drilldownDetails {
+  background: rgba(15, 23, 42, 0.82);
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.08);
+}
+
+.drilldownDetailsHeader {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.drilldownDetailsLabel {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.drilldownDetailsHeader h4 {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.drilldownDetailsHeader h4 span {
+  font-size: 1rem;
+  color: rgba(148, 163, 184, 0.8);
+  font-weight: 500;
+}
+
+.drilldownBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.18);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  font-size: 0.85rem;
+  color: #38bdf8;
+  font-family: var(--font-geist-mono);
+}
+
+.drilldownMetrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.drilldownMetric {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.68);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.drilldownMetricLabel {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.drilldownMetricValue {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.drilldownMetricDetail {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.drilldownInsights {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.drilldownInsights h5 {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.drilldownInsights ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0;
+  margin: 0;
+}
+
+.drilldownInsights li {
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.92);
+}
+
+
 .metricCard {
   background: rgba(15, 23, 42, 0.72);
   border: 1px solid rgba(148, 163, 184, 0.15);
@@ -383,6 +622,14 @@
   .visualGrid {
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   }
+
+  .drilldownBody {
+    grid-template-columns: 1fr;
+  }
+
+  .drilldownList {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  }
 }
 
 @media (max-width: 900px) {
@@ -397,6 +644,41 @@
 
   .chartCanvas {
     height: 240px;
+  }
+
+  .drilldownNav {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .drilldownList {
+    grid-auto-flow: column;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    overflow-x: auto;
+    padding-bottom: 6px;
+  }
+
+  .drilldownList li {
+    min-width: 200px;
+  }
+}
+
+@media (max-width: 600px) {
+  .drilldownSection {
+    padding: 22px;
+  }
+
+  .drilldownMetrics {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .drilldownDetailsHeader {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .drilldownBadge {
+    margin-top: 8px;
   }
 }
 


### PR DESCRIPTION
## Summary
- build a Chrome usage dashboard that loads Chart.js dynamically and renders line, bar, and doughnut visualizations for active time, focus scores, tab counts, and category distribution
- surface weekly insights with summary metrics, highlights, and a detailed table of most visited URLs to track browsing habits
- refresh the home page styling with a dark analytical layout tailored for the new charts and tables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8764493e8832a8416ebcdac12f3ee